### PR TITLE
feat: http_archive

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -56,7 +56,7 @@ def firestore_rules_proto_library(
       **kargs: other keyword arguments that are passed to ts_library.
 
     """
-    outs = _outputs(srcs, ".rules")
+    outs = _outputs(srcs, ".cc")
 
     includes = []
     if include != None:
@@ -75,6 +75,7 @@ def firestore_rules_proto_library(
         plugin = plugin,
         plugin_language = "protoc-gen-firebase_rules",
         plugin_options = ["bazel"],
+        gen_cc = True
     )
 
     firestore_rules_library(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,13 +1,33 @@
-protobuf_commit = "099d99759101c295244c24d8954ec85b8ac65ce3"
-
-protobuf_sha256 = "c0ab1b088e220c1d56446f34001f0178e590270efdef1c46a77da4b9faa9d7b0"
-
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def protobuf_rules_gen_repositories():
     if "com_google_protobuf" not in native.existing_rules():
-        native.http_archive(
+        http_archive(
+            name = "rules_python",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.3.0/rules_python-0.3.0.tar.gz",
+            sha256 = "934c9ceb552e84577b0faf1e5a2f0450314985b4d8712b2b70717dc679fdc01b",
+        )
+        http_archive(
+            name = "bazel_skylib",
+            urls = [
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+            ],
+            sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+        )
+        http_archive(
+            name = "zlib",
+            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+            strip_prefix = "zlib-1.2.11",
+            urls = [
+                "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+                "https://zlib.net/zlib-1.2.11.tar.gz",
+            ],
+        )
+        http_archive(
             name = "com_google_protobuf",
-            sha256 = protobuf_sha256,
-            strip_prefix = "protobuf-" + protobuf_commit,
-            url = "https://github.com/google/protobuf/archive/" + protobuf_commit + ".tar.gz",
+            sha256 = "528927e398f4e290001886894dac17c5c6a2e5548f3fb68004cfb01af901b53a",
+            strip_prefix = "protobuf-3.17.3",
+            urls = ["https://github.com/google/protobuf/archive/v3.17.3.zip"],
         )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -4,16 +4,16 @@ def protobuf_rules_gen_repositories():
     if "com_google_protobuf" not in native.existing_rules():
         http_archive(
             name = "rules_python",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/0.3.0/rules_python-0.3.0.tar.gz",
             sha256 = "934c9ceb552e84577b0faf1e5a2f0450314985b4d8712b2b70717dc679fdc01b",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.3.0/rules_python-0.3.0.tar.gz",
         )
         http_archive(
             name = "bazel_skylib",
+            sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
             urls = [
                 "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
                 "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
             ],
-            sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         )
         http_archive(
             name = "zlib",
@@ -29,5 +29,5 @@ def protobuf_rules_gen_repositories():
             name = "com_google_protobuf",
             sha256 = "528927e398f4e290001886894dac17c5c6a2e5548f3fb68004cfb01af901b53a",
             strip_prefix = "protobuf-3.17.3",
-            urls = ["https://github.com/google/protobuf/archive/v3.17.3.zip"],
+            url = "https://github.com/google/protobuf/archive/v3.17.3.zip",
         )


### PR DESCRIPTION
https://github.com/FirebaseExtended/protobuf-rules-gen/issues/39

I could fix the broken configurations of Bazel.

The build of  any directory exclude `example` succeeded.

The only remaining error is 

```
% bazel build //...                                                                 
ERROR: /home/yu/src/github.com/FirebaseExtended/protobuf-rules-gen/example/BUILD:3:30: in proto_gen rule //example:schema_genproto_rules: 
Traceback (most recent call last):
        File "/home/yu/.cache/bazel/_bazel_yu/40604a59a4d009dade8a4279b557a9f0/external/com_google_protobuf/protobuf.bzl", line 146, column 28, in _proto_gen_impl
                ctx.actions.run(
Error in run: param 'outputs' may not be empty
ERROR: Analysis of target '//example:schema_genproto_rules' failed; build aborted: Analysis of target '//example:schema_genproto_rules' failed
INFO: Elapsed time: 0.067s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
```

@var-const Could you give me some ideas?
